### PR TITLE
Wire decision-consumer into stack

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -64,6 +64,10 @@ defmodule Dispatcher do
   # NOT FOUND
   #################
 
+  match "/decision-consumer/*path" do 
+    Proxy.forward conn, path, "http://decision-consumer/"
+  end
+
   match "/*_", %{ layer: :not_found } do
     send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,9 @@ services:
         condition: service_healthy    # Wait for 'ollama' container to be healthy
     entrypoint: >                     # Use the Ollama REST API to pull the mistral-nemo model
       /bin/sh -c 'curl http://ollama:11434/api/pull -d "{\"name\": \"mistral-nemo\"}" && echo "Curl command completed, model installed."'
-
+  
+  decision-consumer:
+    image: lblod/backend-smart-ipdc-generator-group-8:latest
+  
   tika:
     image: apache/tika:2.9.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,10 @@ services:
   
   decision-consumer:
     image: lblod/backend-smart-ipdc-generator-group-8:latest
+    labels:
+      - "logging=true"
   
   tika:
     image: apache/tika:2.9.2.1
+    labels:
+      - "logging=true"


### PR DESCRIPTION
This PR wires the `decision-consumer` (https://github.com/lblod/backend-smart-ipdc-generator-group-8) into the docker-compose stack.
The decision-consumer can be queried on the `/decision-consumer` subroute.